### PR TITLE
Don't require pdb-symfony-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to these validators with the Symfony Validator component.
 To install this package, add `rollerworks/x509-validator` to your composer.json:
 
 ```bash
-$ php composer.phar require rollerworks/x509-validator
+php composer.phar require rollerworks/x509-validator
 ```
 
 Now, [Composer][composer] will automatically download all required files,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,8 @@
+UPGRADE
+=======
+
+## Upgrade FROM 0.1.0 to 0.2.0
+
+* The `CertificateValidator` now expects a `\Pdp\PublicSuffixList` instance 
+  is passed as first argument, instead of a 
+  `Rollerworks\Component\PdbSfBridge\PdpManager` instance;

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "mlocati/ocsp": "^1.0",
         "psr/clock": "^1.0",
         "rollerworks/pdb-symfony-bridge": "^1.0",
-        "rollerworks/pdb-validator": "^1.0",
         "symfony/translation-contracts": "^2.5 || ^3.0"
     },
     "require-dev": {
@@ -31,6 +30,7 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^10.4.2",
         "rollerscapes/standards": "^1.0",
+        "rollerworks/pdb-symfony-bridge": "^1.0",
         "symfony/clock": "^6.3",
         "symfony/error-handler": "^6.3",
         "symfony/http-client": "^6.3",

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,12 @@ See [Working with validation Violations] below.
 
 ## Using the CertificateValidator
 
-Note that `CertificateValidator` requires a `Rollerworks\Component\PdbSfBridge\PdpManager`
-instance, see https://github.com/rollerworks/PdbSfBridge to set-up a new instance.
+Note that `CertificateValidator` requires a `Pdp\PublicSuffixList`
+instance, see https://github.com/jeremykendall/php-domain-parser#usage
+to set-up a new instance.
+
+**Tip**: For Symfony use the https://github.com/rollerworks/PdbSfBridge
+with out-of-the-box Framework integration.
 
 The `CertificateValidator` validates:
 
@@ -42,13 +46,13 @@ The `CertificateValidator` validates:
   or public-suffix length violations;
 
 ```php
-use Rollerworks\Component\PdbSfBridge\PdpManager;
+use Pdp\PublicSuffixList;
 use Rollerworks\Component\X509Validator\CertificateValidator;
 
-/** @var PdpManager $pdbManager */
-$pdbManager = ...;
+/** @var PublicSuffixList $publicSuffixList */
+$publicSuffixList = ...;
 
-$validator = new CertificateValidator($pdbManager, /*$dataExtractor*/);
+$validator = new CertificateValidator($publicSuffixList, /*$dataExtractor*/);
 
  // PEM X509 encoded certificate string
 $certificate = '';
@@ -182,7 +186,12 @@ The `OCSPValidator` validates the revocation status of a certificate,
 for this to work internet access is required, and the certificate must
 have a CA.
 
-First make sure the ``
+First make sure the `symfony/http-client` package is installed, any 
+`Symfony\Contracts\HttpClient\HttpClientInterface` instance is accepted.
+
+```bash
+php composer.phar require symfony/http-client
+```
 
 This validator should be called after general validation with the `CertificateValidator`.
 

--- a/tests/CertificateValidatorTest.php
+++ b/tests/CertificateValidatorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\X509Validator\Tests;
 
+use Pdp\PublicSuffixList;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
-use Rollerworks\Component\PdbSfBridge\PdpManager;
 use Rollerworks\Component\PdbSfBridge\PdpMockProvider;
 use Rollerworks\Component\X509Validator\CertificateValidator;
 use Rollerworks\Component\X509Validator\TranslatableArgument;
@@ -38,7 +38,7 @@ final class CertificateValidatorTest extends TestCase
 {
     private ClockInterface $clock;
     private CertificateValidator $certificateValidator;
-    private PdpManager $pdpManager;
+    private PublicSuffixList $publicSuffixList;
 
     protected function setUp(): void
     {
@@ -55,8 +55,8 @@ final class CertificateValidatorTest extends TestCase
             }
         };
 
-        $this->pdpManager = PdpMockProvider::getPdpManager();
-        $this->certificateValidator = new CertificateValidator($this->pdpManager, clock: $this->clock);
+        $this->publicSuffixList = PdpMockProvider::getPdpManager()->getPublicSuffixList();
+        $this->certificateValidator = new CertificateValidator($this->publicSuffixList, clock: $this->clock);
     }
 
     #[Test]
@@ -143,7 +143,7 @@ final class CertificateValidatorTest extends TestCase
     #[DataProvider('provideValidate_certificate_host_contains_global_wildcardCases')]
     public function validate_certificate_host_contains_global_wildcard(array $domains, string $provided, string $suffixPattern): void
     {
-        $this->certificateValidator = new FakedCertificateValidator($this->pdpManager);
+        $this->certificateValidator = new FakedCertificateValidator($this->publicSuffixList);
         $this->certificateValidator->setFields([
             '_domains' => $domains,
             '_validTo' => new \DateTimeImmutable('+1 year'),
@@ -179,7 +179,7 @@ final class CertificateValidatorTest extends TestCase
     #[DoesNotPerformAssertions]
     public function validate_certificate_host_wildcard_without_known_prefix_does_not_fail(array $domains): void
     {
-        $this->certificateValidator = new FakedCertificateValidator($this->pdpManager);
+        $this->certificateValidator = new FakedCertificateValidator($this->publicSuffixList);
         $this->certificateValidator->setFields([
             '_domains' => $domains,
             '_validTo' => new \DateTimeImmutable('+1 year'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | Fix #3 
| License       | MIT

We only need a `PublicSuffixList` instance, requiring a Symfony specific implementation would defeat the purpose of using an interface.

Also fixed a small mistake in the documentation.