### PR TITLE
Add parent to CA to for chain storage + make final

### DIFF
--- a/src/CA.php
+++ b/src/CA.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\X509Validator;
 
-class CA
+final readonly class CA
 {
-    public function __construct(private readonly string $contents) {}
-
-    public function getContents(): string
-    {
-        return $this->contents;
-    }
+    public function __construct(
+        public string $contents,
+        public ?self $parent = null
+    ) {}
 }

--- a/src/OCSPValidator.php
+++ b/src/OCSPValidator.php
@@ -84,7 +84,7 @@ readonly class OCSPValidator
         }
 
         $certificateSeq = $this->certificateLoader->fromString($certificate);
-        $issuerCertificate = $this->certificateLoader->fromString($ca->getContents());
+        $issuerCertificate = $this->certificateLoader->fromString($ca->contents);
 
         $ocspResponderUrl = $this->certificateInfo->extractOcspResponderUrl($certificateSeq);
 

--- a/src/Violation/UnableToResolveParent.php
+++ b/src/Violation/UnableToResolveParent.php
@@ -17,8 +17,11 @@ use Rollerworks\Component\X509Validator\Violation;
 
 final class UnableToResolveParent extends Violation
 {
-    public function __construct(private readonly string $name, private readonly string $issuer, int $code = 1)
-    {
+    public function __construct(
+        public readonly string $name,
+        public readonly string $issuer,
+        int $code = 1
+    ) {
         parent::__construct(sprintf('Unable to resolve the parent CA of certificate "%s", issued by "%s".', $name, $issuer), $code);
     }
 

--- a/tests/CAResolverImplTest.php
+++ b/tests/CAResolverImplTest.php
@@ -22,6 +22,7 @@ use Rollerworks\Component\X509Validator\Violation\MissingCAExtension;
 use Rollerworks\Component\X509Validator\Violation\TooManyCAsProvided;
 use Rollerworks\Component\X509Validator\Violation\UnableToResolveParent;
 use Rollerworks\Component\X509Validator\Violation\UnprocessablePEM;
+use Rollerworks\Component\X509Validator\X509Info;
 
 /**
  * @internal
@@ -501,7 +502,7 @@ final class CAResolverImplTest extends TestCase
             'DigiCert SHA2 Secure Server CA' => $ca1,
         ]);
 
-        $intermediateCA = new CA($ca1);
+        $intermediateCA = new CA($ca1, new CA($ca2));
 
         self::assertEquals($intermediateCA, $ca);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Make CAResolverImp and CA model final, this shouldn't be extended but a custom implementation should be used instead.

Storing the CA directly isn't possible, and so it should be transformed to an application level entity instead.
Something like this.

```php
use Doctrine\Persistence\ObjectManager;
use App\TLS\CA;
use Rollerworks\Component\X509Validator\CA as CAInfo;
use Rollerworks\Component\X509Validator\CAResolverImpl;
use Rollerworks\Component\X509Validator\X509DataExtractor;

/**
 * @final
 */
class CAResolver
{
    private X509DataExtractor $extractor;
    private CAResolverImpl $caResolver;

    /**
     * @param ObjectManager<CA> $objectManager
     */
    public function __construct(private ObjectManager $objectManager)
    {
        $this->extractor = new X509DataExtractor();
        $this->caResolver = new CAResolverImpl();
    }

    /**
     * @param array<string, string> $caList
     */
    public function resolve(string $certificate, array $caList): ?CA
    {
        $ca = $this->caResolver->resolve($certificate, $caList);

        if ($ca === null) {
            return null;
        }

        return $this->objectManager->find(CA::class, CA::getHash($ca->contents)) ?? $this->resolveCA($ca);
    }

    private function resolveCA(?CAInfo $ca): CA
    {
        /** @var array<int, string> $tree */
        $tree = [];

        while ($ca !== null) {
            $tree[] = $ca->contents;
            $ca = $ca->parent;
        }

        $parent = null;

        foreach (array_reverse($tree) as $contents) {
            $caEntity = $this->objectManager->find(CA::class, CA::getHash($contents));

            if ($caEntity === null) {
                $x509Info = $this->extractor->extractRawData($contents, '', true);
                $caEntity = new CA($contents, $x509Info->allFields, $parent);
                $this->objectManager->persist($caEntity);
            }

            $parent = $caEntity;
        }

        return $caEntity;
    }
}
```